### PR TITLE
refactor: change distribution url

### DIFF
--- a/coteditor.tera
+++ b/coteditor.tera
@@ -12,7 +12,7 @@ whiskers:
   "metadata" : {
     "author" : "Catppuccin",
     "description" : "Soothing pastel theme for CotEditor",
-    "distributionURL" : "https:\/\/github.com\/Suree33\/coteditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
     "license" : "MIT"
   },
   "background" : {

--- a/themes/catppuccin-frappe.cottheme
+++ b/themes/catppuccin-frappe.cottheme
@@ -3,7 +3,7 @@
   "metadata" : {
     "author" : "Catppuccin",
     "description" : "Soothing pastel theme for CotEditor",
-    "distributionURL" : "https:\/\/github.com\/Suree33\/coteditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
     "license" : "MIT"
   },
   "background" : {

--- a/themes/catppuccin-latte.cottheme
+++ b/themes/catppuccin-latte.cottheme
@@ -3,7 +3,7 @@
   "metadata" : {
     "author" : "Catppuccin",
     "description" : "Soothing pastel theme for CotEditor",
-    "distributionURL" : "https:\/\/github.com\/Suree33\/coteditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
     "license" : "MIT"
   },
   "background" : {

--- a/themes/catppuccin-macchiato.cottheme
+++ b/themes/catppuccin-macchiato.cottheme
@@ -3,7 +3,7 @@
   "metadata" : {
     "author" : "Catppuccin",
     "description" : "Soothing pastel theme for CotEditor",
-    "distributionURL" : "https:\/\/github.com\/Suree33\/coteditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
     "license" : "MIT"
   },
   "background" : {

--- a/themes/catppuccin-mocha.cottheme
+++ b/themes/catppuccin-mocha.cottheme
@@ -3,7 +3,7 @@
   "metadata" : {
     "author" : "Catppuccin",
     "description" : "Soothing pastel theme for CotEditor",
-    "distributionURL" : "https:\/\/github.com\/Suree33\/coteditor",
+    "distributionURL" : "https:\/\/github.com\/catppuccin\/coteditor",
     "license" : "MIT"
   },
   "background" : {


### PR DESCRIPTION

I'm assuming the escaped slashes are there for a reason so I've kept them, but
it is a little odd.
